### PR TITLE
mrc-3226 pipeline to decode logs in json

### DIFF
--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -15,7 +15,7 @@ processors:
         fields: ["message"]
         process_array: false
         max_depth: 1
-        target: "naomi"
+        target: ""
         overwrite_keys: false
         add_error_key: true
         

--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -8,10 +8,10 @@ filebeat.autodiscover:
       hints.enabled: true
 processors:
   - if:
-    equals:
+      equals:
         container.name: "hint_hint"
     then:
-      - decode_json_fields:
+    - decode_json_fields:
         fields: ["message"]
         process_array: false
         max_depth: 1

--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -7,10 +7,14 @@ filebeat.autodiscover:
     - type: docker
       hints.enabled: true
 processors:
-  - decode_json_fields:
-    fields: [ "message" ]
-    process_array: false
-    max_depth: 1
-    target: ""
-    overwrite_keys: false
-    add_error_key: true
+  - if:
+    equals:
+        container.name: "hint_hint"
+    then:
+      - decode_json_fields:
+        fields: ["message"]
+        process_array: false
+        max_depth: 1
+        target: ""
+        overwrite_keys: false
+        add_error_key: true

--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -15,7 +15,7 @@ processors:
         fields: ["message"]
         process_array: false
         max_depth: 1
-        target: ""
+        target: "naomi"
         overwrite_keys: false
         add_error_key: true
         

--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -18,3 +18,4 @@ processors:
         target: ""
         overwrite_keys: false
         add_error_key: true
+        

--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -6,3 +6,11 @@ filebeat.autodiscover:
   providers:
     - type: docker
       hints.enabled: true
+processors:
+  - decode_json_fields:
+    fields: [ "message" ]
+    process_array: false
+    max_depth: 1
+    target: ""
+    overwrite_keys: false
+    add_error_key: true


### PR DESCRIPTION
Filebeat logs are sent to elastic in an encoded format but we want them in decoded json format.

For example, logs get sent in the below format

`{"log":"{\"@timestamp\":\"2022-05-18T16:02:27.924Z\",\"@version\":\"1\",\"logger_name\":\"org.imperial.mrc.hint.logging.GenericLoggerImpl\",\"thread_name\":\"http-nio-8080-exec-5\",\"level\":\"INFO\",\"level_value\":20000,\"Username\":\"test.user@example.com\",\"App\":{\"name\":\"hint\",\"type\":\"backend\"},\"Request\":{\"method\":\"POST\",\"path\":\"/project/7/note\",\"hostname\":\"hint\",\"client\":{\"agent\":\"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0\",\"geoIp\":\"172.18.0.6\",\"sessionId\":\"0BEE1D9BDB3DC9F244B038B6B7D4F10F\"}},\"Response\":null,\"Error\":null,\"Action\":\"Updating project note\",\"Tags\":[\"project\",\"notes\"]}\n","stream":"stdout","time":"2022-05-18T16:02:27.924797862Z"}`

Which causes log data to be stored in message field as text. However, we want this logs to be stored as separate fields, so we require them to be shipped in pure json. Note that the config only applies to hint docker container.


NB: works as expected on testing server