### PR TITLE
mrc-3806: Add machine hostname to filebeat and journalbeat logs

### DIFF
--- a/beats
+++ b/beats
@@ -10,5 +10,6 @@ set +a
 export VAULT_ADDR=https://vault.dide.ic.ac.uk:8200
 ELASTIC_PASSWORD="$(vault read -field=password /secret/logs/users/elastic)"
 export ELASTIC_PASSWORD
+export MACHINE_HOST=$HOSTNAME
 docker-compose pull $BEATS_ENABLED
 docker-compose up -d $BEATS_ENABLED

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ services:
   filebeat:
     command: filebeat -e -strict.perms=false
     environment:
-    - ELASTIC_PASSWORD 
+    - ELASTIC_PASSWORD
+    - MACHINE_HOST
     image: docker.elastic.co/beats/filebeat-oss:$BEATS_VERSION
     restart: unless-stopped
     user: root
@@ -16,6 +17,7 @@ services:
     environment:
     - ELASTIC_PASSWORD
     - SYSLOG_IDENTIFIER
+    - MACHINE_HOST
     image: docker.elastic.co/beats/journalbeat-oss:$BEATS_VERSION
     restart: unless-stopped
     user: root
@@ -23,4 +25,3 @@ services:
     - ./journalbeat.docker.yml:/usr/share/journalbeat/journalbeat.yml:ro
     - /run/log/journal:/run/log/journal:ro
     - /etc/machine-id:/etc/machine-id:ro
-

--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -18,4 +18,6 @@ processors:
         target: ""
         overwrite_keys: false
         add_error_key: true
-        
+  - add_fields:
+      fields:
+        hostname: ${HOSTNAME}

--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -20,4 +20,4 @@ processors:
         add_error_key: true
   - add_fields:
       fields:
-        hostname: ${HOSTNAME}
+        hostname: ${MACHINE_HOST}

--- a/journalbeat.docker.yml
+++ b/journalbeat.docker.yml
@@ -7,3 +7,7 @@ journalbeat.inputs:
     seek: tail
     include_matches:
       - syslog.identifier=${SYSLOG_IDENTIFIER}
+processors:
+  - add_fields:
+      fields:
+        hostname: ${MACHINE_HOST}


### PR DESCRIPTION
This PR will report out the hostname of the host machine in a field `fields.hostname`. At the moment the hostname is reported out at host.name but this is the ID of the beats docker container. We could overwrite that and have the machine hostname there if we think having the beats container ID is not useful (which it probably isn't)

You can see this working if you search for `container.name: hint_hintr AND fields.hostname: wpia-naomi-preview`

![Screenshot_20221115_181525](https://user-images.githubusercontent.com/39248272/201995317-a89153a5-9b2d-4837-91bb-0ff2c49c7a54.png)
