### PR TITLE
mrc-4166 Process nginx logs on ingestion

### DIFF
--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -2,6 +2,7 @@ output.elasticsearch:
   hosts: logs.dide.ic.ac.uk:9200
   username: elastic
   password: ${ELASTIC_PASSWORD}
+  pipeline: "nginx-conditional"
 filebeat.autodiscover:
   providers:
     - type: docker
@@ -11,21 +12,13 @@ processors:
       equals:
         container.name: "hint_hint"
     then:
-    - decode_json_fields:
-        fields: ["message"]
-        process_array: false
-        max_depth: 1
-        target: ""
-        overwrite_keys: false
-        add_error_key: true
-  - if:
-      equals:
-        container.image.name: reside/proxy-nginx:master
-    then:
-    - dissect:
-        tokenizer: '%{clientip|ip} %{user} %{username} [%{timestamp} %{+timestamp}] "%{method} %{request} HTTP/%{httpversion}" %{status} %{bytes} "%{referrer}" "%{useragent}"'
-        field: "message"
-        target_prefix: "nginx"
+      - decode_json_fields:
+          fields: ["message"]
+          process_array: false
+          max_depth: 1
+          target: ""
+          overwrite_keys: false
+          add_error_key: true
   - add_fields:
       fields:
         hostname: ${MACHINE_HOST}

--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -12,13 +12,13 @@ processors:
       equals:
         container.name: "hint_hint"
     then:
-      - decode_json_fields:
-          fields: ["message"]
-          process_array: false
-          max_depth: 1
-          target: ""
-          overwrite_keys: false
-          add_error_key: true
+    - decode_json_fields:
+        fields: ["message"]
+        process_array: false
+        max_depth: 1
+        target: ""
+        overwrite_keys: false
+        add_error_key: true
   - add_fields:
       fields:
         hostname: ${MACHINE_HOST}

--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -6,12 +6,6 @@ filebeat.autodiscover:
   providers:
     - type: docker
       hints.enabled: true
-      appenders:
-        - type: config
-          condition.equals:
-            container.image.name: reside/proxy-nginx:master
-          config:
-            pipeline: nginx
 processors:
   - if:
       equals:

--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -2,6 +2,11 @@ output.elasticsearch:
   hosts: logs.dide.ic.ac.uk:9200
   username: elastic
   password: ${ELASTIC_PASSWORD}
+  if:
+    equals:
+      container.name: "mint-dev_proxy_1"
+  then:
+    pipeline: nginx
 filebeat.autodiscover:
   providers:
     - type: docker

--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -24,6 +24,14 @@ processors:
         target: ""
         overwrite_keys: false
         add_error_key: true
+  - if:
+      equals:
+        container.image.name: reside/proxy-nginx:master
+    then:
+    - dissect:
+        tokenizer: "%{IPORHOST:source.ip} %{USER:user.id} %{USER:user.name} \\[%{HTTPDATE:@timestamp}\\] \"%{WORD:http.request.method} %{DATA:url.original} HTTP/%{NUMBER:http.version}\" %{NUMBER:http.response.status_code:int} (?:-|%{NUMBER:http.response.body.bytes:int}) %{QS:http.request.referrer} %{QS:user_agent}"
+        field: "message"
+        target_prefix: "nginx"
   - add_fields:
       fields:
         hostname: ${MACHINE_HOST}

--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -23,7 +23,7 @@ processors:
         container.image.name: reside/proxy-nginx:master
     then:
     - dissect:
-        tokenizer: "%{IPORHOST:source.ip} %{USER:user.id} %{USER:user.name} \\[%{HTTPDATE:@timestamp}\\] \"%{WORD:http.request.method} %{DATA:url.original} HTTP/%{NUMBER:http.version}\" %{NUMBER:http.response.status_code:int} (?:-|%{NUMBER:http.response.body.bytes:int}) %{QS:http.request.referrer} %{QS:user_agent}"
+        tokenizer: '%{clientip|ip} %{user} %{username} [%{timestamp} %{+timestamp}] "%{method} %{request} HTTP/%{httpversion}" %{status} %{bytes} "%{referrer}" "%{useragent}"'
         field: "message"
         target_prefix: "nginx"
   - add_fields:

--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -2,11 +2,6 @@ output.elasticsearch:
   hosts: logs.dide.ic.ac.uk:9200
   username: elastic
   password: ${ELASTIC_PASSWORD}
-  if:
-    equals:
-      container.name: "mint-dev_proxy_1"
-  then:
-    pipeline: nginx
 filebeat.autodiscover:
   providers:
     - type: docker

--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -11,6 +11,12 @@ filebeat.autodiscover:
   providers:
     - type: docker
       hints.enabled: true
+      appenders:
+        - type: config
+          condition.equals:
+            container.image.name: reside/proxy-nginx:master
+          config:
+            pipeline: nginx
 processors:
   - if:
       equals:


### PR DESCRIPTION
UPDATE: I found that I could not take my original approach of including a custom processor in the config file, as the ip value extracted needed further processing (using geoip) to be useful in the analytics reports. 

It seemed that it would be better to use the existing nginx pipeline which is included in Kibana, and extracts all the information we need. As I mentioned before, you can't put a condition on the pipeline defined in the config file, but you can put a condition on a pipeline when it appears as a processor in another pipeline. So in order to avoid needlessly applying this pipeline to non-nginx container logs, I've created a new pipeline in Kibana, called "nginx-conditional" - this will run the standard nginx pipeline if the originating container image name is our reside proxy. 

The new pipeline can be viewed here: https://logs.dide.ic.ac.uk/app/management/ingest/ingest_pipelines/?pipeline=nginx-conditional

If in future we find that we want to process other sorts of logs in different pipelines, we could include more conditional pipeline processors in `nginx-conditional` (and rename it!) so that it would only run the appropriate pipeline for each document, 

This config is deployed on mint-dev. If you look at [recent mint-dev proxy logs in the Discovery area of the log server](https://logs.dide.ic.ac.uk/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30m,to:now))&_a=(columns:!(),filters:!(),index:'8463ce80-67bf-11eb-8657-49219bf10d1a',interval:auto,query:(language:kuery,query:'container.name%20:%20%22mint-dev_proxy_1%22%20'),sort:!(!('@timestamp',desc)))), you should see that the extracted fields (e.g. those with `geoip` and `http` prefix) are visible when you expand a document. (This link shows logs for the last 30 minutes - if nothing is showing, visit https://mint-dev.dide.ic.ac.uk/ then refresh).